### PR TITLE
Add huggingface checkpoint autodownload and rename sys_msg to model_cards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 demo_m3:
 	cd thirdparty/VILA; \
 	./environment_setup.sh
-	pip install -U python-dotenv deepspeed gradio monai[nibabel,pynrrd,skimage,fire,ignite] torchxrayvision
+	pip install -U python-dotenv deepspeed gradio monai[nibabel,pynrrd,skimage,fire,ignite] torchxrayvision huggingface_hub
 	mkdir -p $(HOME)/.torchxrayvision/models_data/ \
     && wget https://github.com/mlmed/torchxrayvision/releases/download/v1/nih-pc-chex-mimic_ch-google-openi-kaggle-densenet121-d121-tw-lr001-rot45-tr15-sc15-seed0-best.pt \
     -O $(HOME)/.torchxrayvision/models_data/nih-pc-chex-mimic_ch-google-openi-kaggle-densenet121-d121-tw-lr001-rot45-tr15-sc15-seed0-best.pt \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The repository provides a collection of vision language models, benchmarks, and 
 
 ## 💡 News
 
-- [2024/10/31] The fine-tuned VILA-M3-13B checkpoint is released on [HuggingFace](https://huggingface.co/MONAI/Llama3-VILA-M3-13B).
+- [2024/10/31] We released the [VILA-M3-3B](https://huggingface.co/MONAI/Llama3-VILA-M3-3B), [VILA-M3-8B]((https://huggingface.co/MONAI/Llama3-VILA-M3-8B), and [VILA-M3-13B](https://huggingface.co/MONAI/Llama3-VILA-M3-13B) checkpoints on [HuggingFace](https://huggingface.co/MONAI).
 - [2024/10/24] We presented VILA-M3 and the VLM module in MONAI at MONAI Day ([slides](./m3/docs/materials/VILA-M3_MONAI-Day_2024.pdf), [recording - coming soon!](https://www.youtube.com/c/Project-MONAI))
 - [2024/10/24] Interactive [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) is available online!
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The repository provides a collection of vision language models, benchmarks, and 
 
 ## 💡 News
 
+- [2024/10/31] The fine-tuned VILA-M3-13B checkpoint is released on [HuggingFace](https://huggingface.co/MONAI/Llama3-VILA-M3-13B).
 - [2024/10/24] We presented VILA-M3 and the VLM module in MONAI at MONAI Day ([slides](./m3/docs/materials/VILA-M3_MONAI-Day_2024.pdf), [recording - coming soon!](https://www.youtube.com/c/Project-MONAI))
 - [2024/10/24] Interactive [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) is available online!
-- [Coming soon!] Several fine-tuned healthcare checkpoints are released.
 
 ## VILA-M3
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The repository provides a collection of vision language models, benchmarks, and 
 
 ## 💡 News
 
-- [2024/10/31] We released the [VILA-M3-3B](https://huggingface.co/MONAI/Llama3-VILA-M3-3B), [VILA-M3-8B]((https://huggingface.co/MONAI/Llama3-VILA-M3-8B), and [VILA-M3-13B](https://huggingface.co/MONAI/Llama3-VILA-M3-13B) checkpoints on [HuggingFace](https://huggingface.co/MONAI).
+- [2024/10/31] We released the [VILA-M3-3B](https://huggingface.co/MONAI/Llama3-VILA-M3-3B), [VILA-M3-8B](https://huggingface.co/MONAI/Llama3-VILA-M3-8B), and [VILA-M3-13B](https://huggingface.co/MONAI/Llama3-VILA-M3-13B) checkpoints on [HuggingFace](https://huggingface.co/MONAI).
 - [2024/10/24] We presented VILA-M3 and the VLM module in MONAI at MONAI Day ([slides](./m3/docs/materials/VILA-M3_MONAI-Day_2024.pdf), [recording - coming soon!](https://www.youtube.com/c/Project-MONAI))
 - [2024/10/24] Interactive [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) is available online!
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Please visit the [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) to t
     If CUDA is not installed, use one of the following methods:
     - **Recommended** Use the Docker image: `nvidia/cuda:12.2.2-devel-ubuntu22.04`
         ```bash
-        docker run -it --rm --ipc host --gpus all --net host \
-            -v <ckpts_dir>:/data/checkpoints \
+        docker run -it --rm --ipc host --gpus all --net host
             nvidia/cuda:12.2.2-devel-ubuntu22.04 bash
         ```
     - **Manual Installation (not recommended)** Download the appropiate package from [NVIDIA offical page](https://developer.nvidia.com/cuda-12-2-2-download-archive)
@@ -86,14 +85,11 @@ Please visit the [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) to t
 
 1. Start the Gradio demo:
     ```bash
-    python gradio_m3.py  \
-        --modelpath /data/checkpoints/<8B-checkpoint-name> \
-        --convmode llama_3 \
-        --port 7860
+    python gradio_m3.py
     ```
 
-1. Adding your own expert model
-    - This is still a work in progress. Please refer to the [README](m3/demo/experts/README.md) for more details.
+#### Adding your own expert model
+- This is still a work in progress. Please refer to the [README](m3/demo/experts/README.md) for more details.
 
 ## Contributing
 

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -650,13 +650,14 @@ def clear_all_convs(sv: SessionVariables):
     if sv.temp_working_dir is not None:
         rmtree(sv.temp_working_dir)
     new_sv = new_session_variables()
-    # Order of output: prompt_edit, chat_history, history_text, history_text_full, sys_prompt_text, model_cards_text, modality_prompt_dropdown
+    # Order of output: prompt_edit, chat_history, history_text, history_text_full, sys_prompt_text, model_cards_checkbox, model_cards_text, modality_prompt_dropdown
     return (
         new_sv,
         "Enter your prompt here",
         ChatHistory(),
         HTML_PLACEHOLDER,
         HTML_PLACEHOLDER,
+        new_sv.use_model_cards,
         new_sv.sys_prompt,
         new_sv.sys_msg,
         new_sv.modality_prompt,
@@ -822,6 +823,7 @@ def create_demo(source, model_path, conv_mode, server_port):
                 history_text,
                 history_text_full,
                 sys_prompt_text,
+                model_cards_checkbox,
                 model_cards_text,
                 modality_prompt_dropdown,
             ],
@@ -838,6 +840,7 @@ def create_demo(source, model_path, conv_mode, server_port):
                 temperature_slider,
                 top_p_slider,
                 max_tokens_slider,
+                model_cards_checkbox,
                 image_download,
                 image_slider,
             ],

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -304,6 +304,7 @@ class M3Generator:
 
     def __init__(self, source="huggingface", model_path="", conv_mode="", device="cuda"):
         """Initialize the M3 generator"""
+        global SYS_PROMPT
         self.source = source
         # TODO: support huggingface models
         if source == "local":
@@ -325,6 +326,7 @@ class M3Generator:
             logger.info(f"Model {model_name} loaded successfully. Context length: {self.context_len}")
         else:
             raise NotImplementedError(f"Source {source} is not supported.")
+        SYS_PROMPT = conv_templates[self.conv_mode].system  # only set once
 
     def generate_response_local(
         self,
@@ -854,11 +856,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--source",
         type=str,
-        default="local",
-        help="The source of the model. Option is only 'local'.",
+        default="huggingface",
+        help="The source of the model. Option is 'huggingface' or 'local'.",
     )
     args = parser.parse_args()
-    SYS_PROMPT = conv_templates[args.convmode].system
     cache_images()
     create_demo(args.source, args.modelpath, args.convmode, args.port)
     cache_cleanup()

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -679,7 +679,7 @@ def update_sys_prompt(sys_prompt, sv):
     return sv
 
 
-def update_model_cards(use_model_card, model_cards, sv):
+def update_sys_message(use_model_card, model_cards, sv):
     """Update the model cards"""
     logger.debug(f"Updating the model cards")
     if use_model_card:
@@ -737,7 +737,7 @@ def create_demo(source, model_path, conv_mode, server_port):
                         value=sv.value.sys_prompt,
                         lines=4,
                     )
-                    model_cards_checkbox = gr.Checkbox(label="Use Model Cards", checked=False)
+                    model_cards_checkbox = gr.Checkbox(label="Use Model Cards", value=False)
                     model_cards_text = gr.Textbox(
                         label="Model Cards",
                         value=sv.value.sys_msg,
@@ -793,8 +793,8 @@ def create_demo(source, model_path, conv_mode, server_port):
         top_p_slider.change(fn=update_top_p, inputs=[top_p_slider, sv], outputs=[sv])
         max_tokens_slider.change(fn=update_max_tokens, inputs=[max_tokens_slider, sv], outputs=[sv])
         sys_prompt_text.change(fn=update_sys_prompt, inputs=[sys_prompt_text, sv], outputs=[sv])
-        model_cards_checkbox.change(fn=update_model_cards, inputs=[model_cards_checkbox, model_cards_text, sv], outputs=[sv])
-        model_cards_text.change(fn=update_model_cards, inputs=[model_cards_checkbox,model_cards_text, sv], outputs=[sv])
+        model_cards_checkbox.change(fn=update_sys_message, inputs=[model_cards_checkbox, model_cards_text, sv], outputs=[sv])
+        model_cards_text.change(fn=update_sys_message, inputs=[model_cards_checkbox,model_cards_text, sv], outputs=[sv])
         modality_prompt_dropdown.change(fn=update_modality_prompt, inputs=[modality_prompt_dropdown, sv], outputs=[sv])
         # Reset button
         clear_btn.click(

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -456,12 +456,10 @@ class M3Generator:
         if isinstance(img_file, str):
             if "<image>" not in prompt:
                 _prompt = model_cards + "<image>" + mod_msg + prompt
-                logger.debug(f"Appending sys msg: {model_cards + '<image>' + mod_msg}")
                 sv.sys_msgs_to_hide.append(model_cards + "<image>" + mod_msg)
             else:
                 _prompt = model_cards + mod_msg + prompt
                 if model_cards + mod_msg != "":
-                    logger.debug(f"Appending sys msg: {model_cards + mod_msg}")
                     sv.sys_msgs_to_hide.append(model_cards + mod_msg)
 
             if img_file.endswith(".nii.gz"):  # Take the specific slice from a volume
@@ -604,8 +602,7 @@ def colorcode_message(text="", data_url=None, show_all=False, role="user", sys_m
     if not show_all and role == "expert":
         return ""
     if not show_all and sys_msgs_to_hide and isinstance(sys_msgs_to_hide, list):
-        logger.debug(f"Hide the system messages: {sys_msgs_to_hide}")
-        for sys_msg in sys_msgs_to_hide:
+        for sys_msg in sys_msgs_to_hide.sort(key=len, reverse=True):
             text = text.replace(sys_msg, "")
 
     escaped_text = html.escape(text)

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -274,7 +274,7 @@ class SessionVariables:
         """Initialize the session variables"""
         self.sys_prompt = SYS_PROMPT
         self.sys_msg = MODEL_CARDS
-        self.use_model_cards = False
+        self.use_model_cards = True
         self.slice_index = None  # Slice index for 3D images
         self.image_url = None  # Image URL to the image on the web
         self.axis = 2
@@ -286,7 +286,7 @@ class SessionVariables:
         self.idx_range = (None, None)
         self.interactive = False
         self.sys_msgs_to_hide = []
-        self.modality_prompt = "Unknown"
+        self.modality_prompt = "Auto"
 
 
 def new_session_variables(**kwargs):
@@ -865,7 +865,7 @@ if __name__ == "__main__":
         help=(
             "The path to the model to load. "
             "If source is 'local', it can be '/data/checkpoints/vila-m3-8b'. If "
-            "If source is 'huggingface', it can be 'MONAI/Llama3-VILA-M3-13B'."
+            "If source is 'huggingface', it can be 'MONAI/Llama3-VILA-M3-8B'."
         ),
     )
     parser.add_argument(

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -602,7 +602,8 @@ def colorcode_message(text="", data_url=None, show_all=False, role="user", sys_m
     if not show_all and role == "expert":
         return ""
     if not show_all and sys_msgs_to_hide and isinstance(sys_msgs_to_hide, list):
-        for sys_msg in sys_msgs_to_hide.sort(key=len, reverse=True):
+        sys_msgs_to_hide.sort(key=len, reverse=True)
+        for sys_msg in sys_msgs_to_hide:
             text = text.replace(sys_msg, "")
 
     escaped_text = html.escape(text)

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -408,7 +408,7 @@ class M3Generator:
 
     def generate_response(self, **kwargs):
         """Generate the response"""
-        if self.source == "local":
+        if self.source == "local" or self.source == "huggingface":
             return self.generate_response_local(**kwargs)
 
     def squash_expert_messages_into_user(self, messages: list):
@@ -840,12 +840,17 @@ def create_demo(source, model_path, conv_mode, server_port):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # TODO: Add the argument to load multiple models from a JSON file
-    parser.add_argument("--convmode", type=str, default="llama_3", help="The conversation mode to use.")
+    parser.add_argument(
+        "--convmode",
+        type=str,
+        default="vicuna_v1",
+        help="The conversation mode to use. Required if source is 'local'.",
+    )
     parser.add_argument(
         "--modelpath",
         type=str,
         default="/data/checkpoints/vila-m3-8b",
-        help="The path to the model to load.",
+        help="The path to the model to load. Required if source is 'local'.",
     )
     parser.add_argument(
         "--port",

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -14,6 +14,7 @@ import html
 import logging
 import os
 import tempfile
+import time 
 from copy import deepcopy
 from glob import glob
 from shutil import copyfile, rmtree
@@ -368,6 +369,7 @@ class M3Generator:
         keywords = [stop_str]
         stopping_criteria = KeywordsStoppingCriteria(keywords, self.tokenizer, input_ids)
 
+        start_time = time.time()
         with torch.inference_mode():
             output_ids = self.model.generate(
                 input_ids,
@@ -382,6 +384,9 @@ class M3Generator:
                 pad_token_id=self.tokenizer.eos_token_id,
                 min_new_tokens=2,
             )
+        end_time = time.time()
+        logger.debug(f"Time taken to generate tokens {len(output_ids[0])}: {end_time - start_time:.2f} seconds")
+        logger.debug(f"Tokens per second: {len(output_ids[0]) / (end_time - start_time):.2f}")
 
         outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
         outputs = outputs.strip()

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -456,10 +456,12 @@ class M3Generator:
         if isinstance(img_file, str):
             if "<image>" not in prompt:
                 _prompt = model_cards + "<image>" + mod_msg + prompt
+                logger.debug(f"Appending sys msg: {model_cards + '<image>' + mod_msg}")
                 sv.sys_msgs_to_hide.append(model_cards + "<image>" + mod_msg)
             else:
                 _prompt = model_cards + mod_msg + prompt
                 if model_cards + mod_msg != "":
+                    logger.debug(f"Appending sys msg: {model_cards + mod_msg}")
                     sv.sys_msgs_to_hide.append(model_cards + mod_msg)
 
             if img_file.endswith(".nii.gz"):  # Take the specific slice from a volume

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -14,7 +14,7 @@ import html
 import logging
 import os
 import tempfile
-import time 
+import time
 from copy import deepcopy
 from glob import glob
 from shutil import copyfile, rmtree
@@ -698,6 +698,7 @@ def update_model_cards_text(model_cards, sv):
     sv.sys_msg = model_cards
     return sv
 
+
 def update_model_cards_checkbox(use_model_cards, sv):
     """Update the model cards checkbox"""
     logger.debug(f"Updating the model cards checkbox")
@@ -755,7 +756,7 @@ def create_demo(source, model_path, conv_mode, server_port):
                     model_cards_checkbox = gr.Checkbox(
                         label="Use Model Cards",
                         value=sv.value.use_model_cards,
-                        info="Check this to include the model cards of the experts."
+                        info="Check this to include the model cards of the experts.",
                     )
                     model_cards_text = gr.Textbox(label="Model Cards", value=sv.value.sys_msg, lines=8)
                     sys_prompt_text = gr.Textbox(

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -66,8 +66,8 @@ logging.getLogger("gradio").setLevel(logging.WARNING)
 
 # Sample images dictionary. It accepts either a URL or a local path.
 IMG_URLS_OR_PATHS = {
-    # "CT Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/liver_0.nii.gz",
-    # "CT Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/ct_sample.nii.gz",
+    "CT Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/liver_0.nii.gz",
+    "CT Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/ct_sample.nii.gz",
     "Chest X-ray Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_8e067d88-2ea4ee8d-21db2c6b-f78701cb-91ad53f9_v1.jpg",
     "Chest X-ray Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_51e9421b-c2f395da-5dd48889-7e307aca-1472d6a6_v1.jpg",
     "Chest X-ray Sample 3": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_c2af2ab3-6a11cbae-d9fa4d64-21ab221e-cf6f2146_v1.jpg",

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -649,7 +649,7 @@ def clear_all_convs(sv: SessionVariables):
     if sv.temp_working_dir is not None:
         rmtree(sv.temp_working_dir)
     new_sv = new_session_variables()
-    # Order of output: prompt_edit, chat_history, history_text, history_text_full, sys_prompt_text, model_cards_text
+    # Order of output: prompt_edit, chat_history, history_text, history_text_full, sys_prompt_text, model_cards_text, modality_prompt_dropdown
     return (
         new_sv,
         "Enter your prompt here",
@@ -748,7 +748,7 @@ def create_demo(source, model_path, conv_mode, server_port):
                 with gr.Accordion("System Prompt and Message", open=False):
                     modality_prompt_dropdown = gr.Dropdown(
                         label="Select Modality",
-                        choices=["Unknown", "Auto", "CT", "MRI", "X-ray"],
+                        choices=["Unknown", "Auto", "CT", "MRI", "CXR"],
                     )
                     model_cards_checkbox = gr.Checkbox(
                         label="Use Model Cards",

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -604,6 +604,7 @@ def colorcode_message(text="", data_url=None, show_all=False, role="user", sys_m
     if not show_all and role == "expert":
         return ""
     if not show_all and sys_msgs_to_hide and isinstance(sys_msgs_to_hide, list):
+        logger.debug(f"Hide the system messages: {sys_msgs_to_hide}")
         for sys_msg in sys_msgs_to_hide:
             text = text.replace(sys_msg, "")
 

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -66,8 +66,8 @@ logging.getLogger("gradio").setLevel(logging.WARNING)
 
 # Sample images dictionary. It accepts either a URL or a local path.
 IMG_URLS_OR_PATHS = {
-    "CT Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/liver_0.nii.gz",
-    "CT Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/ct_sample.nii.gz",
+    # "CT Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/liver_0.nii.gz",
+    # "CT Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/ct_sample.nii.gz",
     "Chest X-ray Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_8e067d88-2ea4ee8d-21db2c6b-f78701cb-91ad53f9_v1.jpg",
     "Chest X-ray Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_51e9421b-c2f395da-5dd48889-7e307aca-1472d6a6_v1.jpg",
     "Chest X-ray Sample 3": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_c2af2ab3-6a11cbae-d9fa4d64-21ab221e-cf6f2146_v1.jpg",

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -284,7 +284,7 @@ class SessionVariables:
         self.idx_range = (None, None)
         self.interactive = False
         self.sys_msgs_to_hide = []
-        self.modality_prompt = "Auto"
+        self.modality_prompt = "Unknown"
 
 
 def new_session_variables(**kwargs):
@@ -301,7 +301,7 @@ def new_session_variables(**kwargs):
 class M3Generator:
     """Class to generate M3 responses"""
 
-    def __init__(self, source="local", model_path="", conv_mode=""):
+    def __init__(self, source="local", model_path="", conv_mode="", device="cuda"):
         """Initialize the M3 generator"""
         self.source = source
         # TODO: support huggingface models
@@ -314,6 +314,10 @@ class M3Generator:
                 model_path, self.model_name
             )
             logger.info(f"Model {self.model_name} loaded successfully. Context length: {self.context_len}")
+            # warmup
+            warm_up = torch.randn((4096, 4096)).to(device)
+            for i in range(100):
+                torch.mm(warm_up, warm_up)
         elif source == "huggingface":
             pass
         else:
@@ -385,7 +389,7 @@ class M3Generator:
                 min_new_tokens=2,
             )
         end_time = time.time()
-        logger.debug(f"Time taken to generate tokens {len(output_ids[0])}: {end_time - start_time:.2f} seconds")
+        logger.debug(f"Time taken to generate {len(output_ids[0])} tokens: {end_time - start_time:.2f} seconds")
         logger.debug(f"Tokens per second: {len(output_ids[0]) / (end_time - start_time):.2f}")
 
         outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
@@ -737,7 +741,7 @@ def create_demo(source, model_path, conv_mode, server_port):
                     )
                     modality_prompt_dropdown = gr.Dropdown(
                         label="Select Modality",
-                        choices=["Auto", "CT", "MRI", "X-ray", "Unknown"],
+                        choices=["Unknown", "Auto", "CT", "MRI", "X-ray"],
                     )
 
             with gr.Column():

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -840,7 +840,6 @@ def create_demo(source, model_path, conv_mode, server_port):
                 temperature_slider,
                 top_p_slider,
                 max_tokens_slider,
-                model_cards_checkbox,
                 image_download,
                 image_slider,
             ],

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -679,10 +679,13 @@ def update_sys_prompt(sys_prompt, sv):
     return sv
 
 
-def update_sys_message(sys_message, sv):
+def update_model_cards(use_model_card, model_cards, sv):
     """Update the model cards"""
     logger.debug(f"Updating the model cards")
-    sv.sys_msg = sys_message
+    if use_model_card:
+        sv.sys_msg = model_cards
+    else:
+        sv.sys_msg = ""
     return sv
 
 
@@ -734,10 +737,11 @@ def create_demo(source, model_path, conv_mode, server_port):
                         value=sv.value.sys_prompt,
                         lines=4,
                     )
+                    model_cards_checkbox = gr.Checkbox(label="Use Model Cards", checked=False)
                     model_cards_text = gr.Textbox(
                         label="Model Cards",
                         value=sv.value.sys_msg,
-                        lines=10,
+                        lines=8,
                     )
                     modality_prompt_dropdown = gr.Dropdown(
                         label="Select Modality",
@@ -789,7 +793,8 @@ def create_demo(source, model_path, conv_mode, server_port):
         top_p_slider.change(fn=update_top_p, inputs=[top_p_slider, sv], outputs=[sv])
         max_tokens_slider.change(fn=update_max_tokens, inputs=[max_tokens_slider, sv], outputs=[sv])
         sys_prompt_text.change(fn=update_sys_prompt, inputs=[sys_prompt_text, sv], outputs=[sv])
-        model_cards_text.change(fn=update_sys_message, inputs=[model_cards_text, sv], outputs=[sv])
+        model_cards_checkbox.change(fn=update_model_cards, inputs=[model_cards_checkbox, model_cards_text, sv], outputs=[sv])
+        model_cards_text.change(fn=update_model_cards, inputs=[model_cards_checkbox,model_cards_text, sv], outputs=[sv])
         modality_prompt_dropdown.change(fn=update_modality_prompt, inputs=[modality_prompt_dropdown, sv], outputs=[sv])
         # Reset button
         clear_btn.click(

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -272,7 +272,7 @@ class SessionVariables:
     def __init__(self):
         """Initialize the session variables"""
         self.sys_prompt = SYS_PROMPT
-        self.sys_msg = SYS_MSG
+        self.sys_msg = ""
         self.slice_index = None  # Slice index for 3D images
         self.image_url = None  # Image URL to the image on the web
         self.axis = 2
@@ -450,7 +450,8 @@ class M3Generator:
                 sv.sys_msgs_to_hide.append(sv.sys_msg + "<image>" + mod_msg)
             else:
                 _prompt = sv.sys_msg + mod_msg + prompt
-                sv.sys_msgs_to_hide.append(sv.sys_msg + mod_msg)
+                if sv.sys_msg + mod_msg != "":
+                    sv.sys_msgs_to_hide.append(sv.sys_msg + mod_msg)
 
             if img_file.endswith(".nii.gz"):  # Take the specific slice from a volume
                 chat_history.append(
@@ -732,20 +733,20 @@ def create_demo(source, model_path, conv_mode, server_port):
                     )
 
                 with gr.Accordion("System Prompt and Message", open=False):
+                    modality_prompt_dropdown = gr.Dropdown(
+                        label="Select Modality",
+                        choices=["Unknown", "Auto", "CT", "MRI", "X-ray"],
+                    )
+                    model_cards_checkbox = gr.Checkbox(
+                        label="Use Model Cards",
+                        value=False,
+                        info="Check this to include the model cards of the experts."
+                    )
+                    model_cards_text = gr.Textbox(label="Model Cards", value=SYS_MSG, lines=8)
                     sys_prompt_text = gr.Textbox(
                         label="System Prompt",
                         value=sv.value.sys_prompt,
                         lines=4,
-                    )
-                    model_cards_checkbox = gr.Checkbox(label="Use Model Cards", value=False)
-                    model_cards_text = gr.Textbox(
-                        label="Model Cards",
-                        value=sv.value.sys_msg,
-                        lines=8,
-                    )
-                    modality_prompt_dropdown = gr.Dropdown(
-                        label="Select Modality",
-                        choices=["Unknown", "Auto", "CT", "MRI", "X-ray"],
                     )
 
             with gr.Column():

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -657,8 +657,8 @@ def clear_all_convs(sv: SessionVariables):
         ChatHistory(),
         HTML_PLACEHOLDER,
         HTML_PLACEHOLDER,
-        new_sv.use_model_cards,
         new_sv.sys_prompt,
+        new_sv.use_model_cards,
         new_sv.sys_msg,
         new_sv.modality_prompt,
     )

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -303,7 +303,7 @@ def new_session_variables(**kwargs):
 class M3Generator:
     """Class to generate M3 responses"""
 
-    def __init__(self, source="huggingface", model_path="", conv_mode="", device="cuda"):
+    def __init__(self, source="huggingface", model_path="", conv_mode=""):
         """Initialize the M3 generator"""
         global SYS_PROMPT
         self.source = source
@@ -318,8 +318,8 @@ class M3Generator:
             )
             logger.info(f"Model {model_name} loaded successfully. Context length: {self.context_len}")
         elif source == "huggingface":
-            model_path = snapshot_download("MONAI/Llama3-VILA-M3-13B")
-            self.conv_mode = "vicuna_v1"
+            model_path = snapshot_download(model_path)
+            self.conv_mode = conv_mode
             model_name = get_model_name_from_path(model_path)
             self.tokenizer, self.model, self.image_processor, self.context_len = load_pretrained_model(
                 model_path, model_name
@@ -855,14 +855,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--convmode",
         type=str,
-        default="vicuna_v1",
-        help="The conversation mode to use. Required if source is 'local'.",
+        default="llama_3",
+        help="The conversation mode to use. For 8B models, use 'llama_3'. For 3B and 13B models, use 'vicuna_v1'.",
     )
     parser.add_argument(
         "--modelpath",
         type=str,
-        default="/data/checkpoints/vila-m3-8b",
-        help="The path to the model to load. Required if source is 'local'.",
+        default="MONAI/Llama3-VILA-M3-8B",
+        help=(
+            "The path to the model to load. "
+            "If source is 'local', it can be '/data/checkpoints/vila-m3-8b'. If "
+            "If source is 'huggingface', it can be 'MONAI/Llama3-VILA-M3-13B'."
+        ),
     )
     parser.add_argument(
         "--port",


### PR DESCRIPTION
This PR adds
- Auto-download of the 13B huggingface checkpoint
- In order to work with the 13B, disable some "metadata" prompts by default
  - Imaging modality will not be auto-determined, unless the user selects "Auto"
  - Model cards will not be added, unless the user checks "Use Model Cards"

changes
- some "sys_msg" to "model_cards" in variable and function naming.