### PR TITLE
Change URLs for the online samples and make expert model calling more robust in follow-up question

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,10 +1,5 @@
 {
     "projectBaseUrl":"${workspaceFolder}",
-    "ignorePatterns": [
-      {
-        "pattern": "^https://monai.io"
-      }
-    ],
     "timeout": "20s",
     "retryOn429": true,
     "retryCount": 3,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The repository provides a collection of vision language models, benchmarks, and 
 ## 💡 News
 
 - [2024/10/31] We released the [VILA-M3-3B](https://huggingface.co/MONAI/Llama3-VILA-M3-3B), [VILA-M3-8B](https://huggingface.co/MONAI/Llama3-VILA-M3-8B), and [VILA-M3-13B](https://huggingface.co/MONAI/Llama3-VILA-M3-13B) checkpoints on [HuggingFace](https://huggingface.co/MONAI).
-- [2024/10/24] We presented VILA-M3 and the VLM module in MONAI at MONAI Day ([slides](./m3/docs/materials/VILA-M3_MONAI-Day_2024.pdf), [recording - coming soon!](https://www.youtube.com/c/Project-MONAI))
+- [2024/10/24] We presented VILA-M3 and the VLM module in MONAI at MONAI Day ([slides](./m3/docs/materials/VILA-M3_MONAI-Day_2024.pdf), [recording](https://www.youtube.com/watch?v=ApPVTuEtBjc&list=PLtoSVSQ2XzyDOjOn6oDRfEMCD-m-Rm2BJ&index=16))
 - [2024/10/24] Interactive [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) is available online!
 
 ## VILA-M3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The repository provides a collection of vision language models, benchmarks, and 
 
 - [2024/10/31] We released the [VILA-M3-3B](https://huggingface.co/MONAI/Llama3-VILA-M3-3B), [VILA-M3-8B](https://huggingface.co/MONAI/Llama3-VILA-M3-8B), and [VILA-M3-13B](https://huggingface.co/MONAI/Llama3-VILA-M3-13B) checkpoints on [HuggingFace](https://huggingface.co/MONAI).
 - [2024/10/24] We presented VILA-M3 and the VLM module in MONAI at MONAI Day ([slides](./m3/docs/materials/VILA-M3_MONAI-Day_2024.pdf), [recording](https://www.youtube.com/watch?v=ApPVTuEtBjc&list=PLtoSVSQ2XzyDOjOn6oDRfEMCD-m-Rm2BJ&index=16))
-- [2024/10/24] Interactive [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) is available online!
+- [2024/10/24] Interactive [VILA-M3 Demo](https://20.163.25.224/) is available online!
 
 ## VILA-M3
 
@@ -24,7 +24,8 @@ For details, see [here](m3/README.md).
 
 ### Online Demo
 
-Please visit the [VILA-M3 Demo](https://vila-m3-demo.monai.ngc.nvidia.com/) to try out a preview version of the model.
+Please visit the [VILA-M3 Demo](https://20.163.25.224/) to try out a preview version of the model.
+NOTE: The URL `https://vila-m3-demo.monai.ngc.nvidia.com/` is temporarily unavailable. Please use the new URL `https://20.163.25.224/` instead.
 
 <p align="center">
   <img src="m3/docs/images/gradio_app_ct.png" width="70%"/>

--- a/m3/demo/experts/expert_monai_vista3d.py
+++ b/m3/demo/experts/expert_monai_vista3d.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 from pathlib import Path
 from shutil import move
+from uuid import uuid4
 
 import requests
 from experts.base_expert import BaseExpert
@@ -211,6 +212,7 @@ class ExpertVista3D(BaseExpert):
             seg_file = os.path.join(output_dir, "segmentation.nii.gz")
             move(output_file, seg_file)
 
+        seg_image = f"seg_{uuid4()}.jpg"
         text_output = self.segmentation_to_string(
             output_dir,
             img_file,
@@ -218,13 +220,12 @@ class ExpertVista3D(BaseExpert):
             label_groups,
             modality="CT",
             slice_index=slice_index,
-            image_filename=get_slice_filenames(img_file, slice_index)[0],
-            label_filename=get_slice_filenames(img_file, slice_index)[1],
+            image_filename=get_slice_filenames(img_file, slice_index),
+            label_filename=seg_image,
         )
 
         if "segmented" in input:
             instruction = ""  # no need to ask for instruction
         else:
             instruction = "Use this result to respond to this prompt:\n" + prompt
-        mask_overlay = os.path.join(output_dir, get_slice_filenames(img_file, slice_index)[1])
-        return text_output, mask_overlay, instruction, seg_file
+        return text_output, os.path.join(output_dir, seg_image), instruction

--- a/m3/demo/experts/expert_torchxrayvision.py
+++ b/m3/demo/experts/expert_torchxrayvision.py
@@ -319,5 +319,4 @@ class ExpertTXRV(BaseExpert):
             self.classification_to_string(output),
             None,
             "Use this result to respond to this prompt:\n" + prompt,
-            "",  # no file needs to be downloaded
         )

--- a/m3/demo/experts/utils.py
+++ b/m3/demo/experts/utils.py
@@ -145,9 +145,7 @@ def get_filename_from_cd(url, cd):
 def get_slice_filenames(image_file: str, slice_index: int, ext: str = "jpg"):
     """Small helper function to get the slice filenames"""
     base_name = os.path.basename(image_file)
-    image_filename = base_name.replace(".nii.gz", f"_slice{slice_index}_img.{ext}")
-    seg_filename = base_name.replace(".nii.gz", f"_slice{slice_index}_seg.{ext}")
-    return image_filename, seg_filename
+    return base_name.replace(".nii.gz", f"_slice{slice_index}_img.{ext}")
 
 
 def _get_modality_url(image_url_or_path: str | None):

--- a/m3/demo/experts/utils.py
+++ b/m3/demo/experts/utils.py
@@ -150,15 +150,21 @@ def get_slice_filenames(image_file: str, slice_index: int, ext: str = "jpg"):
     return image_filename, seg_filename
 
 
-def _get_modality_url(image_url: str | None):
-    """Hardcoded prompt based on the file path"""
-    if not isinstance(image_url, str):
+def _get_modality_url(image_url_or_path: str | None):
+    """
+    Extract image modality by checking the URL or file path.
+    If the URL or file path contains ".nii.gz" and contain "mri_", then it is MRI, else it is CT.
+    If it contains "cxr_" then it is CXR, otherwise it is Unknown.
+    """
+    if not isinstance(image_url_or_path, str):
         return "Unknown"
-    if image_url.startswith("data:image"):
+    if image_url_or_path.startswith("data:image"):
         return "Unknown"
-    if ".nii.gz" in image_url.lower():
+    if ".nii.gz" in image_url_or_path.lower():
+        if "mri_" in image_url_or_path.lower():
+            return "MRI"
         return "CT"
-    if "cxr_" in image_url.lower():
+    if "cxr_" in image_url_or_path.lower():
         return "CXR"
     return "Unknown"
 

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -511,7 +511,7 @@ class M3Generator:
                     image_url=sv.image_url,
                     input=outputs,
                     output_dir=sv.temp_working_dir,
-                    img_file=img_file,
+                    img_file=CACHED_IMAGES.get(sv.image_url, None),
                     slice_index=sv.slice_index,
                     prompt=prompt,
                 )

--- a/m3/demo/gradio_m3.py
+++ b/m3/demo/gradio_m3.py
@@ -75,9 +75,8 @@ IMG_URLS_OR_PATHS = {
     #     "https://developer.download.nvidia.com/assets/Clara/monai/samples/mri_Brats18_2013_31_1_t2.nii.gz",
     #     "https://developer.download.nvidia.com/assets/Clara/monai/samples/mri_Brats18_2013_31_1_flair.nii.gz",
     # ],
-    "Chest X-ray Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_00030389_006.jpg",
-    "Chest X-ray Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_00030637_016.jpg",
-    "Chest X-ray Sample 3": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_00030788_000.jpg",
+    "Chest X-ray Sample 1": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_00026451_030.jpg",
+    "Chest X-ray Sample 2": "https://developer.download.nvidia.com/assets/Clara/monai/samples/cxr_00029943_005.jpg",
 }
 
 MODEL_CARDS = "Here is a list of available expert models:\n<BRATS(args)> Modality: MRI, Task: segmentation, Overview: A pre-trained model for volumetric (3D) segmentation of brain tumor subregions from multimodal MRIs based on BraTS 2018 data, Accuracy: Tumor core (TC): 0.8559 - Whole tumor (WT): 0.9026 - Enhancing tumor (ET): 0.7905 - Average: 0.8518, Valid args are: None\n<VISTA3D(args)> Modality: CT, Task: segmentation, Overview: domain-specialized interactive foundation model developed for segmenting and annotating human anatomies with precision, Accuracy: 127 organs: 0.792 Dice on average, Valid args are: 'everything', 'hepatic tumor', 'pancreatic tumor', 'lung tumor', 'bone lesion', 'organs', 'cardiovascular', 'gastrointestinal', 'skeleton', or 'muscles'\n<VISTA2D(args)> Modality: cell imaging, Task: segmentation, Overview: model for cell segmentation, which was trained on a variety of cell imaging outputs, including brightfield, phase-contrast, fluorescence, confocal, or electron microscopy, Accuracy: Good accuracy across several cell imaging datasets, Valid args are: None\n<CXR(args)> Modality: chest x-ray (CXR), Task: classification, Overview: pre-trained model which are trained on large cohorts of data, Accuracy: Good accuracy across several diverse chest x-rays datasets, Valid args are: None\nGive the model <NAME(args)> when selecting a suitable expert model.\n"

--- a/m3/tests/test_demo_expert_model.py
+++ b/m3/tests/test_demo_expert_model.py
@@ -77,9 +77,8 @@ class TestExperts(unittest.TestCase):
 class TestExpertUtils(unittest.TestCase):
     def test_filename_slices(self):
         filename = "data/ct_image.nii.gz"
-        img, seg = get_slice_filenames(filename, 0)
+        img  = get_slice_filenames(filename, 0)
         self.assertEqual(img, "ct_image_slice0.jpg")
-        self.assertEqual(seg, "ct_image_slice0_seg.jpg")
 
     def test_monai_transforms(self):
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
This PR
- adds the URL to the recoding of MONAI Day
- adds modality checking for MRI images (a preparation to integrate the BRATS model in the next PR)
- fixes #54 
  - use a uuid to name the mask overlay image generated by the expert model, instead of a fixed name based on the slice.
  - now the user will be able to download all the files generated from the conversation, instead of just the segmentation mask
  - to allow a smooth call of expert model in a follow up question, use `backup` to store multiple variables (image_url + slice_index)